### PR TITLE
fix: フィルタリングを部分一致に変更

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -430,8 +430,10 @@ import {
           const companyElement = card.querySelector(SELECTORS.primary.companyName);
           const companyName = companyElement?.textContent?.trim() || '';
 
-          // フィルター対象企業かチェック
-          if (filteredCompanies.includes(companyName)) {
+          // フィルター対象企業かチェック（部分一致）
+          if (filteredCompanies.some(filterCompany =>
+            filterCompany.length > 0 && companyName.includes(filterCompany)
+          )) {
             // カード自体がグリッドアイテムなので、親の検索は不要
             card.classList.add('youtrust-filter-dimmed');
             card.setAttribute('data-youtrust-filtered', 'true');


### PR DESCRIPTION
## Summary
- 企業名フィルタリングを完全一致から部分一致に変更
- 企業名フィールドに部署名等が含まれる場合（例: `LINEヤフー株式会社 / ハイ…`）でもマッチするように対応
- 空文字列が全てにマッチするのを防止するガード条件を追加

## Changes
- `src/content.ts`: `Array.includes()` → `Array.some()` + `String.includes()`

## Test plan
- [ ] `npm run lint` でエラーがないこと
- [ ] `npm run type-check` で型エラーがないこと
- [ ] `npm run build` でビルド成功
- [ ] 拡張機能をロードして動作確認
  - [ ] 「LINEヤフー株式会社」でフィルタ登録 → 「LINEヤフー株式会社 / 人事部」がフィルタされる
  - [ ] 部分一致で意図しない企業がフィルタされないことを確認

Closes #3