### PR TITLE
Fix grid selector for YOUTRUST layout change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ YOUTRUST.jpの「知り合いかも？」ページで企業名ベースのフィ
 ## CSS Selectors (CRITICAL)
 YOUTRUSTのHTML構造が変わると動作しなくなる可能性あり。
 
-現在のセレクター（2024年確認済み）:
-- カード: `.MuiGrid2-root.MuiGrid2-grid-xs-6`
+現在のセレクター（2026年確認済み）:
+- カード: `.MuiGrid2-root.MuiGrid2-grid-xs-4`
 - 企業名: `.MuiTypography-root.MuiTypography-caption`（最初の要素）
 - ボタン: `[data-click-component-name="friendCandidate"]`
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -37,12 +37,12 @@ import {
   // セレクター定義（MUI Grid2対応）
   const SELECTORS: Selectors = {
     primary: {
-      gridItem: '.MuiGrid2-root.MuiGrid2-grid-xs-6',
+      gridItem: '.MuiGrid2-root.MuiGrid2-grid-xs-4',
       companyName: '.MuiTypography-root.MuiTypography-caption',
       friendButton: '[data-click-component-name="friendCandidate"]'
     },
     fallback: {
-      gridItem: ['div[class*="MuiGrid2-grid-xs-6"]'],
+      gridItem: ['div[class*="MuiGrid2-grid-xs-4"]'],
       companyName: ['span[class*="MuiTypography-caption"]']
     }
   };


### PR DESCRIPTION
## Summary

YOUTRUST updated their website layout, changing the friend candidate card grid from a 2-column layout (`MuiGrid2-grid-xs-6`) to a 3-column layout (`MuiGrid2-grid-xs-4`). This broke the Chrome extension's card detection, causing the filter to stop working. This PR updates the CSS selectors to match the new DOM structure.

## Changes

- Update primary `gridItem` selector from `.MuiGrid2-grid-xs-6` to `.MuiGrid2-grid-xs-4`
- Update fallback `gridItem` selector accordingly
- Update selector documentation in CLAUDE.md (confirmed 2026)