### PR TITLE
Add x-fix-vulnerability skill for npm audit remediation

### DIFF
--- a/.claude/skills/x-fix-vulnerability/SKILL.md
+++ b/.claude/skills/x-fix-vulnerability/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: x-fix-vulnerability
+description: Detect and fix npm audit vulnerabilities (--audit-level=high). DevDependencies only, single root directory.
+---
+
+# Fix Vulnerability
+
+Detect and fix npm audit vulnerabilities, using `npm audit --audit-level=high`.
+
+## Audit Scope
+
+| Directory | Has Dependencies |
+|-----------|-----------------|
+| `/` (root) | devDependencies only |
+
+## Execution
+
+### Phase 1: Audit
+
+1. Run `npm audit --audit-level=high`
+2. Capture the full output including vulnerability count and severity breakdown
+3. If no high/critical vulnerabilities found, report clean and stop
+
+### Phase 2: Branch Management
+
+4. Check working tree: `git status --porcelain`. If dirty, stop and report "Commit or stash changes before running this skill"
+5. Check current branch (`git branch --show-current`) and act accordingly:
+
+   | Current branch | Action |
+   |---------------|--------|
+   | `main` | Proceed to step 6 |
+   | `fix/npm-audit-vulnerabilities` | Skip branch creation, proceed to step 7 |
+   | Other | STOP — ask user to switch to main or abort |
+
+6. Create and switch to development branch:
+   a. Check if branch already exists: `git branch --list fix/npm-audit-vulnerabilities`
+   b. If exists: STOP — report that the branch already exists and ask user to delete it (`git branch -d fix/npm-audit-vulnerabilities`) or switch to it
+   c. If not exists: `git checkout -b fix/npm-audit-vulnerabilities`
+
+### Phase 3: Fix
+
+7. Run `npm audit fix` (never use `--force`)
+8. Re-run `npm audit --audit-level=high` to check remaining issues
+9. For remaining vulnerabilities, determine the fix strategy:
+   - **Direct dependency** (listed in `devDependencies`): bump the version in `package.json` and run `npm install`
+   - **Transitive dependency** (not directly listed): add `overrides` to `package.json` and run `npm install`
+
+### Phase 4: Verify
+
+10. Run `npm run build`
+11. Run `npm test`
+12. Run `npm run lint`
+13. Run `npm run type-check`
+14. If any verification step fails after fixes, revert the problematic change and report the incompatibility
+
+### Phase 5: Report
+
+15. Output a summary (do NOT commit or create a PR — report only):
+
+```
+## Vulnerability Fix Report
+
+### Branch
+- Branch: `fix/npm-audit-vulnerabilities`
+
+### Before
+- Vulnerabilities: X total (Y low, Z moderate, W high, V critical)
+
+### Fixes Applied
+| Package | From | To | Method |
+|---------|------|----|--------|
+
+### After
+- Vulnerabilities: X total (Y low, Z moderate, W high, V critical)
+
+### Verification Results
+- Build (`npm run build`): PASS/FAIL
+- Tests (`npm test`): PASS/FAIL
+- Lint (`npm run lint`): PASS/FAIL
+- Type check (`npm run type-check`): PASS/FAIL
+
+### Manual Intervention Required
+[Any unresolved high/critical vulnerabilities that could not be auto-fixed]
+
+### Next Steps
+Changes are on branch `fix/npm-audit-vulnerabilities` but NOT committed.
+Review the changes with `git diff`, then commit and create a PR manually.
+```
+
+## Rules
+
+- Match audit level: `--audit-level=high`
+- Never use `npm audit fix --force`
+- Never skip build, test, lint, or type-check verification after fixes
+- Both `package.json` and `package-lock.json` changes must be included when committing
+- Report only — do not auto commit or create PRs


### PR DESCRIPTION
## Summary

Add a Claude Code skill (`x-fix-vulnerability`) that automates npm vulnerability detection and remediation for this project. The skill is adapted from the existing reference in `lambda-function-transit`, tailored to this Chrome extension's single-directory, devDependencies-only structure.

## Changes

- Add `.claude/skills/x-fix-vulnerability/SKILL.md` with a 5-phase workflow:
  - **Phase 1 (Audit)**: Run `npm audit --audit-level=high` and capture results
  - **Phase 2 (Branch)**: Manage `fix/npm-audit-vulnerabilities` branch with safety checks
  - **Phase 3 (Fix)**: Apply `npm audit fix` (never `--force`), then bump direct deps or add overrides for transitive deps
  - **Phase 4 (Verify)**: Run `npm run build`, `npm test`, `npm run lint`, `npm run type-check`
  - **Phase 5 (Report)**: Output structured summary without auto-committing or creating PRs
- Key adaptations from reference skill: removed multi-directory logic, added build and type-check verification, separated direct vs transitive dependency fix strategies