### PR TITLE
chore(gitignore): ignore .playwright-mcp artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Build output
 dist/
 
+# Playwright MCP artifacts
+.playwright-mcp/
+
 # Dependencies
 node_modules/
 


### PR DESCRIPTION
## Summary

Add `.playwright-mcp/` to `.gitignore` so the local output produced by the Playwright MCP tool is excluded from version control. The directory holds transient automation artifacts that should not be tracked or shared across environments.

## Changes

- Add a `# Playwright MCP artifacts` section to `.gitignore` with the `.playwright-mcp/` rule