### PR TITLE
chore(skill): replace x-fix-vulnerability with generic workspace-aware version

### DIFF
--- a/.claude/skills/x-fix-vulnerability/SKILL.md
+++ b/.claude/skills/x-fix-vulnerability/SKILL.md
@@ -1,96 +1,283 @@
 ---
 name: x-fix-vulnerability
-description: Detect and fix npm audit vulnerabilities (--audit-level=high). DevDependencies only, single root directory.
+description: npm audit 脆弱性（high 以上）を検出・修正する標準スキル。Node.js プロジェクト汎用。--force 禁止、検証失敗時は自動ロールバック。
+argument-hint: ""
+allowed-tools: Bash(npm:*), Bash(git:*), Bash(pnpm:*), Bash(jq:*), Bash(test:*), Bash(sort:*), Bash(xargs:*), Bash(dirname:*), Bash(sed:*)
 ---
 
-# Fix Vulnerability
+# npm 脆弱性修正スキル（標準版）
 
-Detect and fix npm audit vulnerabilities, using `npm audit --audit-level=high`.
+ルートおよびサブパッケージの npm audit 脆弱性（high 以上）を検出・修正する。
 
-## Audit Scope
+## 前提
 
-| Directory | Has Dependencies |
-|-----------|-----------------|
-| `/` (root) | devDependencies only |
+- **対象レベル**: `--audit-level=high`（high + critical のみ。moderate / low は対象外）
+- **対象ディレクトリ**: プロジェクト構成に応じて自動判定（Step 1 参照）
+- **--force 禁止**: `npm audit fix --force` は使用禁止（メジャーバージョン変更による破壊的変更を防止）
+- **コミット禁止**: スキル内で `git commit` / `git push` は行わない。ユーザーが内容確認後に手動で実施する
 
-## Execution
+## ワークフロー
 
-### Phase 1: Audit
+### Step 1: 事前チェック
 
-1. Run `npm audit --audit-level=high`
-2. Capture the full output including vulnerability count and severity breakdown
-3. If no high/critical vulnerabilities found, report clean and stop
+#### 1-1. ワーキングツリー確認
 
-### Phase 2: Branch Management
+`git status --porcelain` を実行する。
 
-4. Check working tree: `git status --porcelain`. If dirty, stop and report "Commit or stash changes before running this skill"
-5. Check current branch (`git branch --show-current`) and act accordingly:
+- dirty の場合 → **STOP**。「変更をコミットまたは stash してから再実行してください」と報告して中断
 
-   | Current branch | Action |
-   |---------------|--------|
-   | `main` | Proceed to step 6 |
-   | `fix/npm-audit-vulnerabilities` | Skip branch creation, proceed to step 7 |
-   | Other | STOP — ask user to switch to main or abort |
+#### 1-2. 対象ディレクトリの特定
 
-6. Create and switch to development branch:
-   a. Check if branch already exists: `git branch --list fix/npm-audit-vulnerabilities`
-   b. If exists: STOP — report that the branch already exists and ask user to delete it (`git branch -d fix/npm-audit-vulnerabilities`) or switch to it
-   c. If not exists: `git checkout -b fix/npm-audit-vulnerabilities`
+以下の優先順位で対象ディレクトリリストを構築する。
 
-### Phase 3: Fix
+**A. workspaces 宣言を最優先でチェック**
 
-7. Run `npm audit fix` (never use `--force`)
-8. Re-run `npm audit --audit-level=high` to check remaining issues
-9. For remaining vulnerabilities, determine the fix strategy:
-   - **Direct dependency** (listed in `devDependencies`): bump the version in `package.json` and run `npm install`
-   - **Transitive dependency** (not directly listed): add `overrides` to `package.json` and run `npm install`
+1. `pnpm-workspace.yaml` が存在する場合 (pnpm):
+   ```bash
+   pnpm list -r --depth -1 --parseable | sed "s|^$(pwd)||; s|^/||; s|^$|.|"
+   ```
+   出力ディレクトリの絶対パスをリポジトリ root からの相対パスに正規化する。
 
-### Phase 4: Verify
+2. `package.json` に `workspaces` フィールドがある場合 (npm/yarn):
+   ```bash
+   npm query '.workspace' --json | jq -r '.[].location'
+   ```
 
-10. Run `npm run build`
-11. Run `npm test`
-12. Run `npm run lint`
-13. Run `npm run type-check`
-14. If any verification step fails after fixes, revert the problematic change and report the incompatibility
+3. `lerna.json` が存在する場合 (legacy lerna, npm workspaces と併存しない場合のみ):
+   - `lerna.json` の `packages:` 配列のグロブをシェル展開
 
-### Phase 5: Report
+**root (`.`) を対象に含めるかの条件:**
 
-15. Output a summary (do NOT commit or create a PR — report only):
+workspaces 宣言があるリポジトリでは、root が「workspace 定義専用」で audit/fix 対象ではない構成もある（例: pure monorepo の hoisting 用ルート）。以下のコマンドで root `package.json` に実際の依存関係があるかを判定し、ある場合のみ対象リストの先頭に `.` を追加する。
+
+```bash
+jq -e '.dependencies // .devDependencies // .overrides' package.json > /dev/null
+```
+
+- 真 (exit 0): root に依存があり audit 対象 → `.` を含める
+- 偽 (exit 1): workspaces 宣言専用の root → `.` を除外
+
+ws_targets が 0 件かつ root 除外の場合はリスト空 → 下の「対象が 0 件」分岐へ。
+
+**B. workspaces 宣言がない場合 — `git ls-files` フォールバック**
+
+```bash
+git ls-files 'package.json' '**/package.json' | xargs -n1 dirname | sort -u
+```
+
+`.gitignore` 済のパス（`node_modules/`, `.next/`, `dist/`, `build/`, `coverage/` 等）は自動的に除外される。
+
+Git リポジトリでない場合 → **STOP**。「git リポジトリ外のため検出不可。`git init` 後に再実行してください」と報告。
+
+**C. 未コミットの package.json 検知**
+
+```bash
+git ls-files --others --exclude-standard '*package.json'
+```
+
+1 件以上ヒット → **STOP**。「未コミットの package.json が見つかりました。コミットするか `.gitignore` で除外してから再実行してください: <ファイル一覧>」と報告。
+
+**D. 疑わしいパスの検知**
+
+対象リスト中に以下の部分文字列を含むパスがあれば → **STOP**。ユーザーに「このパスは通常 audit 対象外です。明示除外するか、意図して対象にする場合は workspaces 設定を確認してください: <パス一覧>」と報告。
+
+- `/fixtures/`, `/__fixtures__/`
+- `/examples/`
+- `/templates/`
+
+**E. 検出結果の提示と続行**
+
+検出結果を以下のフォーマットで表示し、確認を挟まず Step 1-3 へ進む。
 
 ```
-## Vulnerability Fix Report
+検出: N件の npm プロジェクト (方式: workspaces (npm) | workspaces (pnpm) | workspaces (lerna) | git ls-files)
 
-### Branch
-- Branch: `fix/npm-audit-vulnerabilities`
+- .            (ルート)
+- ./frontend
+- ./src/apis
+```
+
+対象が 0 件の場合 → **STOP**。以下の文言で中断する:
+
+```
+npm プロジェクトが見つかりませんでした。以下を確認してください:
+- カレントディレクトリがリポジトリのルートか
+- package.json が実在するか (`ls package.json`)
+- git ls-files で検出できる状態か (コミット済みか)
+```
+
+#### 1-3. ブランチ確認
+
+`git branch --show-current` で現在ブランチを確認する。
+
+| ブランチ | 対応 |
+|---------|------|
+| `main` または `master` | Step 2 へ続行 |
+| `fix/npm-audit-*` で始まるブランチ | ブランチ作成をスキップし Step 3 へ |
+| その他 | **STOP**。「main に切り替えてから再実行するか、現在のブランチで続行するか選択してください」とユーザーに確認 |
+
+### Step 2: 監査（Audit）
+
+各対象ディレクトリで以下を実行する。
+
+> **`--prefix` の扱い**: 対象がリポジトリ root（`.`）の場合は `--prefix` を省略する。サブディレクトリ（Step 1-2 で検出された非 root パス）の場合のみ `--prefix <dir>` を付与する。以降の Step でも同じ規則を適用する。
+
+1. `npm audit --json [--prefix <dir>]` — 機械可読な脆弱性データを取得
+2. `npm audit [--prefix <dir>]` — 人間可読なサマリーを取得
+
+**脆弱性 0 件**（全ディレクトリ） → 「脆弱性なし」と報告して正常終了
+
+**1 件以上** → 各脆弱性について以下を記録する:
+- パッケージ名・現バージョン
+- 深刻度（critical / high）
+- Advisory ID・説明
+- 依存パス（直接依存 or 推移依存）
+- `npm audit fix` で修正可能か
+
+`npm ls <package> [--prefix <dir>]` で依存ツリーを確認し、影響範囲を把握する。
+
+### Step 3: ブランチ作成
+
+Step 1-3 で `main` / `master` にいた場合のみ実行する。
+
+1. `git pull origin <current-branch>` で最新化
+2. 主要な脆弱性パッケージ名からブランチ名を生成する:
+   - 先頭の `@` を除去し、`/` を `-` に置換
+   - 例: `path-to-regexp` → `fix/npm-audit-path-to-regexp`
+   - 例: `@babel/traverse` → `fix/npm-audit-babel-traverse`
+   - 脆弱性が複数パッケージにまたがる場合は `fix/npm-audit-YYYYMMDD`（日付ベース）を使用
+3. `git branch --list <branch-name>` で既存ブランチの有無を確認
+   - 存在する場合 → **STOP**。ユーザーに既存ブランチの削除・切り替え・サフィックス付与のいずれかを確認
+4. `git switch -c <branch-name>` でブランチ作成
+5. `git branch --show-current` で切り替え成功を確認
+
+### Step 4: 自動修正（Fix）
+
+#### 4-1. npm audit fix
+
+各対象ディレクトリで `npm audit fix [--prefix <dir>]` を実行する（`--force` は**絶対に使わない**）。
+
+#### 4-2. 残存脆弱性の確認
+
+`npm audit --audit-level=high [--prefix <dir>]` を再実行し、残存脆弱性を確認する。
+
+すべて解決済みなら Step 5 へ。
+
+#### 4-3. overrides による修正
+
+残存脆弱性について、以下の OK 条件を**すべて**満たす場合のみ `overrides` を自動追記する。
+
+**OK 条件（すべて必須）:**
+1. 対象が**推移依存**（transitive dependency）である。`package.json` の `dependencies` / `devDependencies` に直接記載されていない
+2. npm advisory が修正先バージョンを明示している
+3. 修正先がメジャーバージョン差分をまたがない（例: `1.x → 1.y` は OK、`1.x → 2.x` は NG）
+4. `npm view <package> versions --json` で修正先バージョンの存在を確認できる
+
+**NG 条件（いずれかに該当したら自動修正しない）:**
+- 対象が直接依存
+- メジャーバージョンをまたぐ
+- 修正先バージョンが不明または存在しない
+
+OK の場合:
+1. 該当 `package.json` の `overrides` セクションに追記
+2. `npm install [--prefix <dir>]` を実行して適用
+3. 追記内容（パッケージ名・from・to）を記録
+
+NG の場合:
+- 手動対応としてレポートに記録し、修正は行わない
+
+### Step 5: 副作用チェック
+
+修正適用後、想定外の影響がないか確認する。
+
+`git diff --stat` および `git status --porcelain` を実行し、以下のいずれかに該当したら **STOP** してユーザーに手動確認を依頼する:
+
+- `package.json` / `package-lock.json` 以外のファイルに変更が入っている
+- `package-lock.json` のインデントフォーマットが大幅に変化（tab ↔ space）
+- audit 対象と無関係な依存が多数更新されている
+
+問題がなければ Step 6 へ。
+
+### Step 6: 検証（Verify）
+
+各対象ディレクトリで以下を順に実行する。プロジェクトに存在するコマンドのみ実行する。
+
+| 検証項目 | コマンド例 | 目的 |
+|---------|-----------|------|
+| ユニットテスト | `npm test [--prefix <dir>]` | 機能的な回帰がないか |
+| リント | `npm run lint [--prefix <dir>]` | コード品質の維持 |
+| ビルド | `npm run build [--prefix <dir>]` | ランタイム依存の破綻検知 |
+| Docker テスト | `npm run test:docker [--prefix <dir>]` | コンテナ環境での互換性（存在する場合のみ） |
+
+#### 検証失敗時のロールバック
+
+いずれかの検証が失敗した場合:
+
+```bash
+git checkout -- package.json package-lock.json
+# サブパッケージがある場合は各ディレクトリの package.json / package-lock.json も対象
+npm install [--prefix <dir>]
+```
+
+でロールバックし、「`npm audit fix` / `overrides` が {test|lint|build} を壊しました。手動介入が必要です」と具体的な失敗内容とともに報告して中断する。
+
+### Step 7: 結果報告（Report）
+
+以下の形式でレポートを出力する。**コミットと push は行わない**。
+
+```markdown
+## 脆弱性修正レポート
+
+### ブランチ
+- 現ブランチ: `<branch-name>`
+
+### 対象ディレクトリ
+- <dir1>, <dir2>, ...
 
 ### Before
-- Vulnerabilities: X total (Y low, Z moderate, W high, V critical)
+| ディレクトリ | high | critical | 合計 |
+|-------------|------|----------|------|
+<!-- Step 1-2 で検出された各ディレクトリごとに 1 行 -->
+| <dir>       | X    | Y        | Z    |
 
-### Fixes Applied
-| Package | From | To | Method |
-|---------|------|----|--------|
+### 修正内容
+| パッケージ | From | To | 方法 | ディレクトリ | Advisory |
+|-----------|------|----|------|-------------|----------|
+| xxx       | 1.2.3 | 1.2.4 | npm audit fix | / | GHSA-xxxx |
+| yyy       | 2.0.0 | 2.1.0 | overrides     | /frontend | GHSA-yyyy |
+
+### 依存パス
+- package: parent -> child -> vulnerable-package
 
 ### After
-- Vulnerabilities: X total (Y low, Z moderate, W high, V critical)
+| ディレクトリ | high | critical | 合計 |
+|-------------|------|----------|------|
+<!-- Step 1-2 で検出された各ディレクトリごとに 1 行 -->
+| <dir>       | X    | Y        | Z    |
 
-### Verification Results
-- Build (`npm run build`): PASS/FAIL
-- Tests (`npm test`): PASS/FAIL
-- Lint (`npm run lint`): PASS/FAIL
-- Type check (`npm run type-check`): PASS/FAIL
+### 検証結果
+| 項目 | 結果 |
+|------|------|
+| npm test | PASS / FAIL |
+| npm run lint | PASS / FAIL |
+| npm run build | PASS / FAIL |
+| npm run test:docker | PASS / FAIL / N/A |
 
-### Manual Intervention Required
-[Any unresolved high/critical vulnerabilities that could not be auto-fixed]
+### 手動対応が必要な残存脆弱性
+| パッケージ | 深刻度 | 理由 | Advisory URL | 推奨対応 |
+|-----------|--------|------|-------------|---------|
+| zzz       | high   | 直接依存のためoverrides不可 | https://... | パッケージのメジャーアップグレードを検討 |
 
-### Next Steps
-Changes are on branch `fix/npm-audit-vulnerabilities` but NOT committed.
-Review the changes with `git diff`, then commit and create a PR manually.
+### 次のアクション
+- `git diff` で変更内容を確認後、ユーザーが手動でコミット・PR 作成
 ```
 
-## Rules
+## ルール
 
-- Match audit level: `--audit-level=high`
-- Never use `npm audit fix --force`
-- Never skip build, test, lint, or type-check verification after fixes
-- Both `package.json` and `package-lock.json` changes must be included when committing
-- Report only — do not auto commit or create PRs
+- `--audit-level=high` を維持（moderate / low は対象外）
+- `npm audit fix --force` は使用禁止
+- 検証（test / lint / build）失敗時は必ずロールバックしてユーザーに報告
+- **コミットと push はスキル内で行わない**（内容確認後にユーザーが手動で実施）
+- `overrides` は推移依存かつメジャー差分をまたがない場合のみ追加。直接依存は手動対応
+- `package.json` と `package-lock.json` の両方が変更対象となることに留意
+- 副作用チェック（Step 5）で想定外の変更を検出した場合は必ず停止する


### PR DESCRIPTION
## Summary

Replaces the project-local `x-fix-vulnerability` skill with the generic, workspace-aware version authored in a sibling repository. The new skill detects npm/pnpm/lerna workspaces (falling back to `git ls-files` for single-root repos), adds rollback on verification failure, and gates automatic `overrides` injection on safety conditions (transitive-only, no major bump, registry existence check). The file was copied verbatim; no content changes were applied in this repo.

Because this project is single-root with `devDependencies` only, the skill's behavior remains functionally close to the previous version. The main operational differences to be aware of: verification no longer runs `npm run type-check` (run it manually after the skill completes), and a `git pull origin <branch>` is now invoked before branch creation.

## Changes

- Replace `.claude/skills/x-fix-vulnerability/SKILL.md` with the generic 12,467-byte version (Japanese, workspace-aware, 7-step flow)
- Add `allowed-tools` frontmatter (`Bash(npm:*), Bash(git:*), Bash(pnpm:*), Bash(jq:*), Bash(test:*), Bash(sort:*), Bash(xargs:*), Bash(dirname:*), Bash(sed:*)`) to enable non-interactive skill execution
- Adopt richer report format with per-directory before/after tables, dependency path disclosure, and manual-intervention section