### PR TITLE
fix(deps): bump fast-uri to 3.1.2 to resolve high severity advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1235,9 +1235,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3340,9 +3340,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
Patches the only high severity finding from `npm audit` by bumping the transitive `fast-uri` dependency from 3.1.0 to 3.1.2. This addresses a path traversal vulnerability (GHSA-q3j6-qgpj-74h6) and a host confusion vulnerability (GHSA-v39h-62p7-jpjc). The change was applied via `npm audit fix` (no `--force`), so no major version bumps occur and `package.json` is untouched.

## Changes
- Upgrade `fast-uri` 3.1.0 -> 3.1.2 (transitive devDependency via jest)
- Incidental `@tootallnate/once` 2.0.0 -> 2.0.1 patch from the same audit fix
- All checks pass: `npm test` (47/47), `npm run lint` (0 errors), `npm run type-check`, `npm run build`