### PR TITLE
chore(skill): rename x-fix-vulnerability to x-fixing-vulnerability

### DIFF
--- a/.claude/skills/x-fixing-vulnerability/SKILL.md
+++ b/.claude/skills/x-fixing-vulnerability/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: x-fix-vulnerability
-description: npm audit 脆弱性（high 以上）を検出・修正する標準スキル。Node.js プロジェクト汎用。--force 禁止、検証失敗時は自動ロールバック。
+name: x-fixing-vulnerability
+description: Node.js プロジェクトで npm audit が報告する high / critical 脆弱性を検出して修正する。「脆弱性を直して」「npm audit 直して」「security fix」「vulnerability fix」などの指示、または依存関係の脆弱性対応を求められたときに使用する。npm workspaces / pnpm / lerna / 単一 root を自動判定し、`--force` を使わず `npm audit fix` と `overrides` のみで修正する。検証失敗時は自動でロールバックする。
 argument-hint: ""
 allowed-tools: Bash(npm:*), Bash(git:*), Bash(pnpm:*), Bash(jq:*), Bash(test:*), Bash(sort:*), Bash(xargs:*), Bash(dirname:*), Bash(sed:*)
 ---
@@ -13,10 +13,22 @@ allowed-tools: Bash(npm:*), Bash(git:*), Bash(pnpm:*), Bash(jq:*), Bash(test:*),
 
 - **対象レベル**: `--audit-level=high`（high + critical のみ。moderate / low は対象外）
 - **対象ディレクトリ**: プロジェクト構成に応じて自動判定（Step 1 参照）
-- **--force 禁止**: `npm audit fix --force` は使用禁止（メジャーバージョン変更による破壊的変更を防止）
+- **--force 禁止**: `npm audit fix --force` は使用禁止
 - **コミット禁止**: スキル内で `git commit` / `git push` は行わない。ユーザーが内容確認後に手動で実施する
 
 ## ワークフロー
+
+### Step 0: 事前チェック早見表
+
+Step 1 で実施する pre-flight 判定の概要。詳細条件と STOP 文言は Step 1-1〜1-3 を参照する。
+
+- [ ] **Step 1-1**: ワーキングツリーが clean か（dirty なら STOP）
+- [ ] **Step 1-2**: 対象ディレクトリが 1 件以上検出できるか（workspaces 宣言 → なければ `git ls-files` フォールバック）
+- [ ] **Step 1-2C**: 未コミットの `package.json` がないか（あれば STOP）
+- [ ] **Step 1-2D**: 疑わしいパス（`/fixtures/`, `/examples/`, `/templates/`）が含まれていないか（あれば STOP）
+- [ ] **Step 1-3**: 現在ブランチが `main` / `master` / `fix/npm-audit-*` か（その他はユーザー確認）
+
+このチェックは要約であり、Step 1 の各サブステップが正規の判定処理。
 
 ### Step 1: 事前チェック
 
@@ -24,7 +36,7 @@ allowed-tools: Bash(npm:*), Bash(git:*), Bash(pnpm:*), Bash(jq:*), Bash(test:*),
 
 `git status --porcelain` を実行する。
 
-- dirty の場合 → **STOP**。「変更をコミットまたは stash してから再実行してください」と報告して中断
+- dirty の場合 → **STOP**。「変更を commit または stash 後に再実行が必要」と報告して中断する
 
 #### 1-2. 対象ディレクトリの特定
 
@@ -34,6 +46,7 @@ allowed-tools: Bash(npm:*), Bash(git:*), Bash(pnpm:*), Bash(jq:*), Bash(test:*),
 
 1. `pnpm-workspace.yaml` が存在する場合 (pnpm):
    ```bash
+   # --depth -1 = workspace root のみ展開
    pnpm list -r --depth -1 --parseable | sed "s|^$(pwd)||; s|^/||; s|^$|.|"
    ```
    出力ディレクトリの絶対パスをリポジトリ root からの相対パスに正規化する。
@@ -48,7 +61,7 @@ allowed-tools: Bash(npm:*), Bash(git:*), Bash(pnpm:*), Bash(jq:*), Bash(test:*),
 
 **root (`.`) を対象に含めるかの条件:**
 
-workspaces 宣言があるリポジトリでは、root が「workspace 定義専用」で audit/fix 対象ではない構成もある（例: pure monorepo の hoisting 用ルート）。以下のコマンドで root `package.json` に実際の依存関係があるかを判定し、ある場合のみ対象リストの先頭に `.` を追加する。
+root の `package.json` に依存があれば対象リスト先頭に `.` を追加する:
 
 ```bash
 jq -e '.dependencies // .devDependencies // .overrides' package.json > /dev/null
@@ -65,9 +78,7 @@ ws_targets が 0 件かつ root 除外の場合はリスト空 → 下の「対�
 git ls-files 'package.json' '**/package.json' | xargs -n1 dirname | sort -u
 ```
 
-`.gitignore` 済のパス（`node_modules/`, `.next/`, `dist/`, `build/`, `coverage/` 等）は自動的に除外される。
-
-Git リポジトリでない場合 → **STOP**。「git リポジトリ外のため検出不可。`git init` 後に再実行してください」と報告。
+Git リポジトリでない場合 → **STOP**。「git リポジトリ外のため検出不可。`git init` 後に再実行が必要」と報告する。
 
 **C. 未コミットの package.json 検知**
 
@@ -75,11 +86,13 @@ Git リポジトリでない場合 → **STOP**。「git リポジトリ外の�
 git ls-files --others --exclude-standard '*package.json'
 ```
 
-1 件以上ヒット → **STOP**。「未コミットの package.json が見つかりました。コミットするか `.gitignore` で除外してから再実行してください: <ファイル一覧>」と報告。
+1 件以上ヒット → **STOP**。「未コミットの package.json: commit または `.gitignore` 除外後に再実行が必要: <ファイル一覧>」と報告する。
 
 **D. 疑わしいパスの検知**
 
-対象リスト中に以下の部分文字列を含むパスがあれば → **STOP**。ユーザーに「このパスは通常 audit 対象外です。明示除外するか、意図して対象にする場合は workspaces 設定を確認してください: <パス一覧>」と報告。
+対象リスト中に以下の部分文字列を含むパスがあれば → **STOP**。ユーザーに「通常 audit 対象外のパスを検出。明示除外、または workspaces 設定の確認が必要: <パス一覧>」と報告する。
+
+一般的に audit 対象外とされる慣習ディレクトリ名:
 
 - `/fixtures/`, `/__fixtures__/`
 - `/examples/`
@@ -90,7 +103,7 @@ git ls-files --others --exclude-standard '*package.json'
 検出結果を以下のフォーマットで表示し、確認を挟まず Step 1-3 へ進む。
 
 ```
-検出: N件の npm プロジェクト (方式: workspaces (npm) | workspaces (pnpm) | workspaces (lerna) | git ls-files)
+検出: N件の対象ディレクトリ (方式: workspaces (npm) | workspaces (pnpm) | workspaces (lerna) | git ls-files)
 
 - .            (ルート)
 - ./frontend
@@ -100,7 +113,7 @@ git ls-files --others --exclude-standard '*package.json'
 対象が 0 件の場合 → **STOP**。以下の文言で中断する:
 
 ```
-npm プロジェクトが見つかりませんでした。以下を確認してください:
+対象ディレクトリが見つかりませんでした。以下を確認する:
 - カレントディレクトリがリポジトリのルートか
 - package.json が実在するか (`ls package.json`)
 - git ls-files で検出できる状態か (コミット済みか)
@@ -114,7 +127,7 @@ npm プロジェクトが見つかりませんでした。以下を確認して�
 |---------|------|
 | `main` または `master` | Step 2 へ続行 |
 | `fix/npm-audit-*` で始まるブランチ | ブランチ作成をスキップし Step 3 へ |
-| その他 | **STOP**。「main に切り替えてから再実行するか、現在のブランチで続行するか選択してください」とユーザーに確認 |
+| その他 | **STOP**。「main 切り替え後の再実行、または現在ブランチで続行のいずれかを選択」とユーザーに確認する |
 
 ### Step 2: 監査（Audit）
 
@@ -155,7 +168,7 @@ Step 1-3 で `main` / `master` にいた場合のみ実行する。
 
 #### 4-1. npm audit fix
 
-各対象ディレクトリで `npm audit fix [--prefix <dir>]` を実行する（`--force` は**絶対に使わない**）。
+各対象ディレクトリで `npm audit fix [--prefix <dir>]` を実行する。
 
 #### 4-2. 残存脆弱性の確認
 
@@ -214,7 +227,7 @@ NG の場合:
 いずれかの検証が失敗した場合:
 
 ```bash
-git checkout -- package.json package-lock.json
+git restore package.json package-lock.json
 # サブパッケージがある場合は各ディレクトリの package.json / package-lock.json も対象
 npm install [--prefix <dir>]
 ```
@@ -279,5 +292,4 @@ npm install [--prefix <dir>]
 - 検証（test / lint / build）失敗時は必ずロールバックしてユーザーに報告
 - **コミットと push はスキル内で行わない**（内容確認後にユーザーが手動で実施）
 - `overrides` は推移依存かつメジャー差分をまたがない場合のみ追加。直接依存は手動対応
-- `package.json` と `package-lock.json` の両方が変更対象となることに留意
 - 副作用チェック（Step 5）で想定外の変更を検出した場合は必ず停止する


### PR DESCRIPTION
## Summary

- Rename `.claude/skills/x-fix-vulnerability/` → `.claude/skills/x-fixing-vulnerability/` to match the user's `/x-<verb>ing-` gerund convention (Anthropic Skill authoring best practices)
- Apply best-practices edits to the SKILL body: 3rd-person description with explicit trigger phrases, new Step 0 pre-flight index, terminology unification, redundancy cuts, `git restore` modernization

## Changes

- `name:` frontmatter field renamed to `x-fixing-vulnerability` (matches dirname; passes `^[a-z][a-z0-9-]{0,63}$`)
- `description:` rewritten in 3rd-person Japanese with explicit trigger phrases (「脆弱性を直して」「npm audit 直して」「security fix」「vulnerability fix」など) and explicit constraints (`--force` 禁止 / 検証失敗時の自動ロールバック)
- New `### Step 0: 事前チェック早見表` inserted under `## ワークフロー` as an index of the existing Step 1-1〜1-3 pre-flight judgments (no new STOP conditions — `git ls-files` subpackage fallback and non-target-branch user-confirm path preserved)
- Terminology unified: `npm プロジェクト` → `対象ディレクトリ` (2 sites)
- 3rd-person normalization on 5 prose STOP messages
- 4-5 redundant explanations removed (concepts Claude already knows)
- 2 magic-constant inline comments added (`pnpm list --depth -1`, audit-excluded directory conventions)
- Step 6 rollback: `git checkout -- ...` → `git restore ...`

## Verification

- [x] `yaml.safe_load` parses the frontmatter cleanly
- [x] `name` field equals dirname (`x-fixing-vulnerability`)
- [x] Name matches `^[a-z][a-z0-9-]{0,63}$`
- [x] No stale `x-fix-vulnerability` references under `.claude/`
- [x] `npm run lint` and `npm run type-check` pass
- [x] `git diff --stat` limited to the renamed SKILL.md

## Note

- `.claude/settings.local.json` L13-14 also reference the old path. The file is gitignored at the user level (`~/.config/git/ignore`), so the local fix is not included in this PR — it must be applied manually by anyone with that file checked in.
- The Claude Code skill registry refreshes mid-session on rename, so no Code session restart is required.

Closes #12