### PR TITLE
chore(skills): rename skill to x-fixing-vulnerabilities

### DIFF
--- a/.claude/skills/x-fixing-vulnerabilities/SKILL.md
+++ b/.claude/skills/x-fixing-vulnerabilities/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: x-fixing-vulnerability
+name: x-fixing-vulnerabilities
 description: Node.js プロジェクトで npm audit が報告する high / critical 脆弱性を検出して修正する。「脆弱性を直して」「npm audit 直して」「security fix」「vulnerability fix」などの指示、または依存関係の脆弱性対応を求められたときに使用する。npm workspaces / pnpm / lerna / 単一 root を自動判定し、`--force` を使わず `npm audit fix` と `overrides` のみで修正する。検証失敗時は自動でロールバックする。
 argument-hint: ""
 allowed-tools: Bash(npm:*), Bash(git:*), Bash(pnpm:*), Bash(jq:*), Bash(test:*), Bash(sort:*), Bash(xargs:*), Bash(dirname:*), Bash(sed:*)


### PR DESCRIPTION
## Summary
Renames the project-local Claude Code skill `x-fixing-vulnerability` to the plural `x-fixing-vulnerabilities`, so the name matches the skill's batch behavior (it fixes all high/critical npm audit findings in one pass) and the sibling `x-cleaning-branches` plural naming convention.

## Changes
- Renamed `.claude/skills/x-fixing-vulnerability/` to `.claude/skills/x-fixing-vulnerabilities/` via `git mv` (history preserved)
- Updated `SKILL.md` line 2 frontmatter: `name: x-fixing-vulnerability` -> `name: x-fixing-vulnerabilities`, keeping the directory name and `name:` field in sync so the skill registers
- Local-only (untracked, not in this diff): updated 2 stale path references in `.claude/settings.local.json` from `x-fixing-vulnerability/SKILL.md` to `x-fixing-vulnerabilities/SKILL.md`

## Verification
Commands run:
- `npm run lint` - passed (0 errors; 5 pre-existing warnings unrelated to this change)
- `npm run type-check` - passed
- `npm run test` - passed (4 suites, 47/47 tests)
- x-code-reviewer review - zero Critical, zero Warning findings

Acceptance criteria (graded by an independent verifier that ran each command):
- [x] MET: `ls -d .claude/skills/*/ && test ! -d .claude/skills/x-fixing-vulnerability && test -f .claude/skills/x-fixing-vulnerabilities/SKILL.md` - new directory exists, old directory gone, SKILL.md at new path
- [x] MET: `grep -n '^name: x-fixing-vulnerabilities$' .claude/skills/x-fixing-vulnerabilities/SKILL.md` - outputs line 2
- [x] MET: `grep -rnw 'x-fixing-vulnerability' .claude/skills/` - no output (exit 1)
- [x] MET: YAML frontmatter check - prints `OK x-fixing-vulnerabilities` (name equals directory name)
- [x] MET: `.claude/settings.local.json` - valid JSON, zero stale old-path references (`no stale refs`)

Note: after merge, a Claude Code session restart is required for `/x-fixing-vulnerabilities` to load; the old `/x-fixing-vulnerability` command no longer resolves.

Closes #19