### PR TITLE
fix(deps): resolve high-severity brace-expansion, fast-uri, js-yaml advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -741,9 +741,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3330,9 +3330,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -4770,9 +4770,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -5131,9 +5131,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "minimatch@9.0.0 - 9.0.6": "9.0.9",
     "serialize-javascript": "7.0.5",
     "minimatch@9.0.9": {
-      "brace-expansion": "2.1.3"
+      "brace-expansion": "2.1.4"
     }
   },
   "jest": {


### PR DESCRIPTION
## Summary
- `npm audit --audit-level=high` reported 4 high-severity vulnerabilities: `brace-expansion`, `fast-uri`, `js-yaml`
- `fast-uri` and `js-yaml` fixed automatically via `npm audit fix`
- `brace-expansion` (transitive dep of `minimatch`) fixed by updating the existing `overrides["minimatch@9.0.9"].brace-expansion` pin from `2.1.3` → `2.1.4` — the newer advisory (GHSA-rgw5-rvv9-x895) shows `2.1.3` bypasses the prior CVE-2026-14257 mitigation, and `2.1.4` stays within the same major version
- `npm audit` now reports **0 vulnerabilities**

## Details
| Package | From | To | Method | Advisory |
|---|---|---|---|---|
| fast-uri | 3.0.0–3.1.4 | patched | `npm audit fix` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) |
| js-yaml | 3.x/4.x (vulnerable range) | patched | `npm audit fix` | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) |
| brace-expansion | 2.1.3 | 2.1.4 | `overrides` (transitive, no major bump) | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) |

All are dev-only transitive dependencies (eslint/typescript-eslint/jest toolchain); no runtime/production code is affected.

## Test plan
- [x] `npm audit --audit-level=high` → 0 vulnerabilities
- [x] `npm test` → 47/47 tests passed
- [x] `npm run lint` → 0 errors (pre-existing warnings only)
- [x] `npm run build` → production build succeeds
- [x] `git diff --stat` limited to `package.json` / `package-lock.json`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01F56LTGNfQkhsdCNsAfMEZw

---
_Generated by [Claude Code](https://claude.ai/code/session_01F56LTGNfQkhsdCNsAfMEZw)_